### PR TITLE
Fix pagination issues with multiple grids on one page

### DIFF
--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -483,10 +483,6 @@ class Model
             $this->perPage = (int) $perPage;
         }
 
-        if (isset($paginate['arguments'][0])) {
-            return $paginate['arguments'];
-        }
-
         if ($name = $this->grid->getName()) {
             return [$this->perPage, ['*'], "{$name}_page"];
         }


### PR DESCRIPTION
 If you have multiple grids on one page, with pagination, using `->paginate()`, the parameter will be changed to whatever you've set using `$grid->setName()`.